### PR TITLE
fix: rimosso import inutile di matplotlib da piano_studio.py e aggiornato requirements.txt

### DIFF
--- a/modules/piano_studio.py
+++ b/modules/piano_studio.py
@@ -1,6 +1,5 @@
 
 import streamlit as st
-import matplotlib.pyplot as plt
 import pandas as pd
 from datetime import datetime, timedelta, date
 import plotly.express as px

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ langchain
 langchain-community
 python-dotenv
 pandas
-matplotlib
+plotly


### PR DESCRIPTION
- Eliminato import matplotlib.pyplot in piano_studio.py (non necessario)
- Corretto requirements.txt: rimosso matplotlib, aggiunto plotly