### PR TITLE
fix: rimosso matplotlib, aggiunto plotly e reportlab al progetto LLMentor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ langchain-community
 python-dotenv
 pandas
 plotly
+reportlab


### PR DESCRIPTION
fix: sistemato piano_studio.py, aggiornato requirements.txt con plotly e reportlab
- Eliminato import matplotlib.pyplot
- Aggiunto plotly per grafici e reportlab per esportazione PDF